### PR TITLE
Adjust schedule typography

### DIFF
--- a/client/stylesheets/bootstrap-variables.import.less
+++ b/client/stylesheets/bootstrap-variables.import.less
@@ -50,7 +50,7 @@
 @font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
 @font-family-base:        @font-family-sans-serif;
 
-@font-size-base:          15px;
+@font-size-base:          16px;
 @font-size-large:         ceil((@font-size-base * 1.25)); // ~18px
 @font-size-small:         12px; // ~12px
 

--- a/client/views/schedule/schedule.html
+++ b/client/views/schedule/schedule.html
@@ -11,14 +11,14 @@
         <!-- EVENTUALLY POPULATE THIS WITH JS -->
         <div class="row" id="icon-row">
             <div class="col-xs-12 col-md-8 col-md-push-2">
-                <h2 class="uppercase" style="margin: 0 auto;">Schedule</h2>
+                <h2 class="uppercase">schedule</h2>
 
-                <h3 class="uppercase">Day 1</h3>
+                <h3>Saturday, January 30th</h3>
                 <table class="table centered-table">
                     <thead>
                         <tr>
-                            <th class="time uppercase">Time</th>
-                            <th class="event uppercase">Event</th>
+                            <th class="text-center">Time</th>
+                            <th class="text-center">Event</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -45,12 +45,12 @@
 
         <div class="row" id="icon-row">
             <div class="col-xs-12 col-md-8 col-md-push-2">
-                <h3 class="uppercase">Day 2</h3>
-                <table class="table">
+                <h3>Sunday, January 31st</h3>
+                <table class="table centered-table">
                     <thead>
                         <tr>
-                            <th class="time uppercase">Time</th>
-                            <th class="event uppercase">Event</th>
+                            <th class="text-center">Time</th>
+                            <th class="text-center">Event</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/client/views/schedule/schedule.import.less
+++ b/client/views/schedule/schedule.import.less
@@ -9,7 +9,7 @@
     }
     table {
         width: initial;
-        font-size: 16px;
+        font-size: @font-size-base;
     }
     tr td:nth-child(1) {
         text-align: right;

--- a/client/views/schedule/schedule.import.less
+++ b/client/views/schedule/schedule.import.less
@@ -1,18 +1,20 @@
 #schedule
 {
-	h3 {
-		margin-top: 40px;
-	}
-  table {
-  	margin-top: 20px;
-  	margin-bottom: 20px;
-  }
-}
-
-.time {
-	text-align: center;
-}
-
-.event {
-	text-align: center;
+    h2 {
+        font-weight: bold;
+        margin: 0 auto;
+    }
+    h3 {
+        margin-top: 40px;
+    }
+    table {
+        width: initial;
+        font-size: 16px;
+    }
+    tr td:nth-child(1) {
+        text-align: right;
+    }
+    tr td:nth-child(2) {
+        text-align: left;
+    }
 }


### PR DESCRIPTION
I adjusted the typography of the schedule tables for better readability and appearance. Since the table's `font-size` seemed too small at `14px`, I manually set it to `16px`. Ideally, this would be done through the `@font-size-base` variable in `bootstrap-variables.import.less`, but it doesn't seem to be working.

![image](https://cloud.githubusercontent.com/assets/1497826/9069376/c4de7212-3a9d-11e5-84c3-2eb22a04210d.png)
